### PR TITLE
Update to use Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,5 +8,5 @@ inputs:
   token:
     description: 'The GITHUB_TOKEN secret'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
This updates to Node 16 because Node 12 is deprecated and recommended to be updated [here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)